### PR TITLE
fix: cancel earlier workflows on same sha

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ async function main() {
       });
       console.log(`Found ${data.total_count} runs total.`);
       const runningWorkflows = data.workflow_runs.filter(
-        workflow => workflow.head_branch === branch && workflow.head_sha !== headSha && workflow.status !== 'completed'
+        workflow => workflow.head_branch === branch && workflow.head_sha !== headSha && workflow.status !== 'completed' && workflow.run_number < GITHUB_RUN_ID
       );
       console.log(`Found ${runningWorkflows.length} runs in progress.`);
       for (const {id, head_sha, status} of runningWorkflows) {


### PR DESCRIPTION
We're not doing enough to cancel runs particularly duplicate runs of the same SHA. If the action finds a workflow run that matches the id, sha, and branch name, cancel it if it is earlier than the current run.

This is to support solving this bug: https://rentpath.atlassian.net/browse/DX-167